### PR TITLE
Applying the 'opens in a window or tab' hidden link consistently with a space inside the span than outside.

### DIFF
--- a/src/components/LinkToGuidance.svelte
+++ b/src/components/LinkToGuidance.svelte
@@ -49,5 +49,5 @@
   </svg>
   <span>
     <slot />
-  </span> <span class="visuallyhidden">(opens in a new window or tab)</span>
+  </span><span class="visuallyhidden"> (opens in a new window or tab)</span>
 </a>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -48,7 +48,7 @@
 <tr class="result-row" id="{catalogCriteria.alt_id}{extraId}">
   <td>
     <a href="{standard.url}#{catalogCriteria.alt_id}" target="_blank">
-      {criteria.num} {catalogCriteria.handle} <span class="visuallyhidden">(opens in a new window or tab)</span>
+      {criteria.num} {catalogCriteria.handle}<span class="visuallyhidden"> (opens in a new window or tab)</span>
     </a>
   </td>
   <td>

--- a/src/components/report/ReportHTMLDownload.svelte
+++ b/src/components/report/ReportHTMLDownload.svelte
@@ -141,7 +141,7 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="grid-col">
-            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="visuallyhidden">(opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA <span class="visuallyhidden">(opens in a new window or tab)</span></a>. The content is the responsibility of the author.
+            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="visuallyhidden"> (opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA<span class="visuallyhidden"> (opens in a new window or tab)</span></a>. The content is the responsibility of the author.
           </div>
           <div class="grid-col">
             <ReportLicense />

--- a/src/components/report/ReportHeader.svelte
+++ b/src/components/report/ReportHeader.svelte
@@ -47,9 +47,9 @@
         {#if $evaluation["author"]["name"]}<li>Name: {$evaluation["author"]["name"]}</li>{/if}
         {#if $evaluation["author"]["company_name"]}<li>Company: {$evaluation["author"]["company_name"]}</li>{/if}
         {#if $evaluation["author"]["address"]}<li>Address: {$evaluation["author"]["address"]}</li>{/if}
-        {#if $evaluation["author"]["email"]}<li>Email: <a href="mailto:{$evaluation['author']['email']}" target="_blank">{$evaluation["author"]["email"]} <span class="visuallyhidden">(opens in a new window or tab)</span></a></li>{/if}
+        {#if $evaluation["author"]["email"]}<li>Email: <a href="mailto:{$evaluation['author']['email']}" target="_blank">{$evaluation["author"]["email"]}<span class="visuallyhidden"> (opens in a new window or tab)</span></a></li>{/if}
         {#if $evaluation["author"]["phone"]}<li>Phone: {$evaluation["author"]["phone"]}</li>{/if}
-        {#if $evaluation["author"]["website"]}<li>Website: <a href="{$evaluation['author']['website']}" target="_blank">{$evaluation["author"]["website"]} <span class="visuallyhidden">(opens in a new window or tab)</span></a></li>{/if}
+        {#if $evaluation["author"]["website"]}<li>Website: <a href="{$evaluation['author']['website']}" target="_blank">{$evaluation["author"]["website"]}<span class="visuallyhidden"> (opens in a new window or tab)</span></a></li>{/if}
       </ul>
     </div>
   {/if}
@@ -60,9 +60,9 @@
         {#if $evaluation["vendor"]["name"]}<li>Name: {$evaluation["vendor"]["name"]}</li>{/if}
         {#if $evaluation["vendor"]["company_name"]}<li>Company: {$evaluation["vendor"]["company_name"]}</li>{/if}
         {#if $evaluation["vendor"]["address"]}<li>Address: {$evaluation["vendor"]["address"]}</li>{/if}
-        {#if $evaluation["vendor"]["email"]}<li>Email: <a href="mailto:{$evaluation['vendor']['email']}" target="_blank">{$evaluation["vendor"]["email"]} <span class="visuallyhidden">(opens in a new window or tab)</span></a></li>{/if}
+        {#if $evaluation["vendor"]["email"]}<li>Email: <a href="mailto:{$evaluation['vendor']['email']}" target="_blank">{$evaluation["vendor"]["email"]}<span class="visuallyhidden"> (opens in a new window or tab)</span></a></li>{/if}
         {#if $evaluation["vendor"]["phone"]}<li>Phone: {$evaluation["vendor"]["phone"]}</li>{/if}
-        {#if $evaluation["vendor"]["website"]}<li>Website: <a href="{$evaluation['vendor']['website']}" target="_blank">{$evaluation["vendor"]["website"]} <span class="visuallyhidden">(opens in a new window or tab)</span></a></li>{/if}
+        {#if $evaluation["vendor"]["website"]}<li>Website: <a href="{$evaluation['vendor']['website']}" target="_blank">{$evaluation["vendor"]["website"]}<span class="visuallyhidden"> (opens in a new window or tab)</span></a></li>{/if}
       </ul>
     </div>
   {/if}
@@ -96,7 +96,7 @@
     <tbody>
       {#each catalog.standards as standard }
         <tr>
-          <td><a href="{standard.url}" target="_blank">{standard.label} <span class="visuallyhidden">(opens in a new window or tab)</span></a></td>
+          <td><a href="{standard.url}" target="_blank">{standard.label}<span class="visuallyhidden"> (opens in a new window or tab)</span></a></td>
           <td>{@html standardsIncluded($evaluation.catalog, standard.chapters)}</td>
         </tr>
       {/each}

--- a/src/components/report/ReportSummary.svelte
+++ b/src/components/report/ReportSummary.svelte
@@ -14,18 +14,18 @@
 {/if}
 {#if $evaluation["repository"]}
   <HeaderWithAnchor id="repository" level=2 {download}>Repository</HeaderWithAnchor>
-  <a href="{$evaluation["repository"]}" target="_blank">{$evaluation["repository"]} <span class="visuallyhidden">(opens in a new window or tab)</span></a>
+  <a href="{$evaluation["repository"]}" target="_blank">{$evaluation["repository"]}<span class="visuallyhidden"> (opens in a new window or tab)</span></a>
 {/if}
 {#if $evaluation["feedback"]}
   <HeaderWithAnchor id="feedback" level=2 {download}>Feedback</HeaderWithAnchor>
-  <a href="{$evaluation["feedback"]}" target="_blank">{$evaluation["feedback"]} <span class="visuallyhidden">(opens in a new window or tab)</span></a>
+  <a href="{$evaluation["feedback"]}" target="_blank">{$evaluation["feedback"]}<span class="visuallyhidden"> (opens in a new window or tab)</span></a>
 {/if}
 {#if $evaluation["related_openacrs"] && $evaluation["related_openacrs"].length > 0}
   <HeaderWithAnchor id="related-openacrs" level=2 {download}>Related OpenACRs</HeaderWithAnchor>
   <ul>
     {#each $evaluation["related_openacrs"] as related}
       {#if related.url}
-        <li><a href="{related.url}" target="_blank">{related.url} ({related.type}) <span class="visuallyhidden">(opens in a new window or tab)</span></a></li>
+        <li><a href="{related.url}" target="_blank">{related.url} ({related.type})<span class="visuallyhidden"> (opens in a new window or tab)</span></a></li>
       {/if}
     {/each}
   </ul>

--- a/src/components/report/ReportZipDownload.svelte
+++ b/src/components/report/ReportZipDownload.svelte
@@ -150,7 +150,7 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="grid-col">
-            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="visuallyhidden">(opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA <span class="visuallyhidden">(opens in a new window or tab)</span></a>. The content is the responsibility of the author.
+            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="visuallyhidden"> (opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA<span class="visuallyhidden"> (opens in a new window or tab)</span></a>. The content is the responsibility of the author.
           </div>
           <div class="grid-col">
             <ReportLicense />

--- a/src/index.html
+++ b/src/index.html
@@ -212,26 +212,26 @@
           </p>
           <div class="button-group">
             <a href="mailto:openacr@gsa.gov" class="button" target="_blank"
-              ><span>E-mail</span>
-              <span class="visuallyhidden"
-                >(opens in a new window or tab)</span
+              ><span>E-mail</span
+              ><span class="visuallyhidden">
+                (opens in a new window or tab)</span
               ></a
             >
             <a
               href="https://github.com/GSA/openacr-editor"
               class="button"
               target="_blank"
-              ><span>Fork &amp; Edit on GitHub</span>
-              <span class="visuallyhidden"
-                >(opens in a new window or tab)</span
+              ><span>Fork &amp; Edit on GitHub</span
+              ><span class="visuallyhidden">
+                (opens in a new window or tab)</span
               ></a
             ><a
               href="https://github.com/GSA/openacr-editor/issues/new"
               class="button"
               target="_blank"
-              ><span>New GitHub Issue</span>
-              <span class="visuallyhidden"
-                >(opens in a new window or tab)</span
+              ><span>New GitHub Issue</span
+              ><span class="visuallyhidden">
+                (opens in a new window or tab)</span
               ></a
             >
           </div>
@@ -252,34 +252,32 @@
         <p><strong>Version:</strong> v0.1.0</p>
         <p>
           <a href="https://github.com/GSA/openacr" target="_blank"
-            >OpenACR
-            <span class="visuallyhidden"
-              >(opens in a new window or tab)</span
+            >OpenACR<span class="visuallyhidden">
+              (opens in a new window or tab)</span
             ></a
           >
           is a format maintained by the
           <a href="https://gsa.gov/" target="_blank"
-            >U.S. General Services Administration (GSA)
-            <span class="visuallyhidden"
-              >(opens in a new window or tab)</span
+            >U.S. General Services Administration (GSA)<span
+              class="visuallyhidden"
+            >
+              (opens in a new window or tab)</span
             ></a
           >. The content is the responsibility of the author.
         </p>
         <p>
           This software includes material copied from or derived from
           <a href="https://github.com/w3c/wai-atag-report-tool" target="_blank"
-            >W3C ATAG Report Tool (ART)
-            <span class="visuallyhidden"
-              >(opens in a new window or tab)</span
+            >W3C ATAG Report Tool (ART)<span class="visuallyhidden">
+              (opens in a new window or tab)</span
             ></a
           >
           and Copyright © 2021 W3C® (MIT, ERCIM, Keio, Beihang).
           <a
             href="https://www.w3.org/Consortium/Legal/copyright-software"
             target="_blank"
-            >W3C Software notice and license
-            <span class="visuallyhidden"
-              >(opens in a new window or tab)</span
+            >W3C Software notice and license<span class="visuallyhidden">
+              (opens in a new window or tab)</span
             ></a
           >.
         </p>

--- a/src/routes/Acknowledgements.svelte
+++ b/src/routes/Acknowledgements.svelte
@@ -22,7 +22,7 @@
 <Header>Acknowledgements</Header>
 
 <p>
-  The OpenACR Editor was developed by <a href="https://civicactions.com/" target="_blank">CivicActions <span class="visuallyhidden">(opens in a new window or tab)</span></a> and <a href="https://www.gsa.gov/" target="_blank">U.S. General Services Administration (GSA) <span class="visuallyhidden">(opens in a new window or tab)</span></a>
+  The OpenACR Editor was developed by <a href="https://civicactions.com/" target="_blank">CivicActions<span class="visuallyhidden"> (opens in a new window or tab)</span></a> and <a href="https://www.gsa.gov/" target="_blank">U.S. General Services Administration (GSA)<span class="visuallyhidden"> (opens in a new window or tab)</span></a>
 </p>
 
 <HeaderWithAnchor id="project-team" level=2>Project Team</HeaderWithAnchor>

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -28,7 +28,7 @@
 <Header>Overview</Header>
 
 <p>
-  This web editor helps evaluators build Accessibility Conformance Reports in the <a href="https://github.com/gsa/openacr" target="_blank">OpenACR format <span class="visuallyhidden">(opens in a new window or tab)</span></a>.
+  This web editor helps evaluators build Accessibility Conformance Reports in the <a href="https://github.com/gsa/openacr" target="_blank">OpenACR format<span class="visuallyhidden"> (opens in a new window or tab)</span></a>.
   It is designed to help accessibility subject matter experts create machine-readable OpenACR documents. Authors will be guided in creating an
   accessible report for the digital product or service that they are documenting. Conformance for each requirement can be documented as required
   to generate a Section 508 report.
@@ -51,7 +51,7 @@
     to edit the report the future without the YAML file.
   </li>
   <li>
-    You can add limited formatting to your report with <a href="https://en.wikipedia.org/wiki/Markdown" target="_blank">Markdown <span class="visuallyhidden">(opens in a new window or tab)</span></a>. This allows you to add
+    You can add limited formatting to your report with <a href="https://en.wikipedia.org/wiki/Markdown" target="_blank">Markdown<span class="visuallyhidden"> (opens in a new window or tab)</span></a>. This allows you to add
     lists, links and code examples.
   </li>
 </ul>
@@ -78,7 +78,7 @@
     will make it easier to provide feedback to vendors. Comparisons will make it easier to update reports.
   </p>
   <p>
-    For more information, see <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="visuallyhidden">(opens in a new window or tab)</span></a>.
+    For more information, see <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="visuallyhidden"> (opens in a new window or tab)</span></a>.
   </p>
 </details>
 

--- a/src/utils/license.js
+++ b/src/utils/license.js
@@ -7,7 +7,12 @@ export function license(evaluation, templateType) {
       return sanitizeHtml(
         `<a href="${spdxLicenseList[evaluation.license].url}" target="_blank">${
           spdxLicenseList[evaluation.license].name
-        } <span class="visuallyhidden">(opens in a new window or tab)</span></a>`
+        }<span class="visuallyhidden"> (opens in a new window or tab)</span></a>`,
+        {
+          allowedClasses: {
+            span: ["visuallyhidden"],
+          },
+        }
       );
     } else {
       return `[${spdxLicenseList[evaluation.license].name}](${


### PR DESCRIPTION
Realized that external links underline appears with an extra trailing space so cleaning that up. Also fixing the license to not show the 'opens in a window or tab' text.