### PR TITLE
Feature/12 disabled chapters

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:10001",
-  "video": true,
+  "video": false,
   "videosFolder": "cypress/results",
   "reporter": "junit",
   "reporterOptions": {

--- a/cypress/integration/report.test.js
+++ b/cypress/integration/report.test.js
@@ -245,7 +245,21 @@ describe("Report", () => {
 
     cy.get("button").contains("View Report").click();
 
+    cy.get(".applicable-standards-guidelines-table").should(
+      "not.contain",
+      "Chapter 4: Hardware"
+    );
+
+    cy.get("#hardware-editor").should("not.exist");
+
     cy.get("#hardware-editor + table").should("not.exist");
+
+    cy.get(".applicable-standards-guidelines-table").should(
+      "contain",
+      "Chapter 5: Software"
+    );
+
+    cy.get("#software-summary").should("exist");
 
     cy.get("#software-summary + table").should("exist");
   });

--- a/src/components/report/ReportChapter.svelte
+++ b/src/components/report/ReportChapter.svelte
@@ -43,7 +43,9 @@
   }
 </style>
 
-<HeaderWithAnchor id={chapterId} level=3 {download}>{chapter.label}</HeaderWithAnchor>
+{#if !$evaluation['chapters'][chapterId]['disabled'] || $evaluation['chapters'][chapterId]['notes']}
+  <HeaderWithAnchor id={chapterId} level=3 {download}>{chapter.label}</HeaderWithAnchor>
+{/if}
 
 {#if $evaluation['chapters'][chapterId]['notes']}
   <div id="{chapterId}-notes" class="chapter-notes-section">

--- a/src/components/report/ReportHeader.svelte
+++ b/src/components/report/ReportHeader.svelte
@@ -97,7 +97,7 @@
       {#each catalog.standards as standard }
         <tr>
           <td><a href="{standard.url}" target="_blank">{standard.label}<span class="visuallyhidden"> (opens in a new window or tab)</span></a></td>
-          <td>{@html standardsIncluded($evaluation.catalog, standard.chapters)}</td>
+          <td>{@html standardsIncluded($evaluation.catalog, standard.chapters, $evaluation.chapters)}</td>
         </tr>
       {/each}
     </tbody>

--- a/src/utils/getCatalogItems.js
+++ b/src/utils/getCatalogItems.js
@@ -18,7 +18,10 @@ export function standardsIncluded(
   const result = [];
   for (const standardChapter of standardChapters) {
     const catalogChapter = getCatalogChapter(catalogName, standardChapter);
-    if (!evaluationChapters[standardChapter].disabled) {
+    if (
+      !evaluationChapters[standardChapter].disabled ||
+      evaluationChapters[standardChapter].notes
+    ) {
       result.push(`<li>${catalogChapter.label}</li>`);
     }
   }

--- a/src/utils/getCatalogItems.js
+++ b/src/utils/getCatalogItems.js
@@ -10,11 +10,17 @@ export function getCatalogChapter(catalogName, chapterId) {
   }
 }
 
-export function standardsIncluded(catalogName, standardChapters) {
+export function standardsIncluded(
+  catalogName,
+  standardChapters,
+  evaluationChapters
+) {
   const result = [];
   for (const standardChapter of standardChapters) {
     const catalogChapter = getCatalogChapter(catalogName, standardChapter);
-    result.push(`<li>${catalogChapter.label}</li>`);
+    if (!evaluationChapters[standardChapter].disabled) {
+      result.push(`<li>${catalogChapter.label}</li>`);
+    }
   }
   return sanitizeHtml(`<ul>${result.join("")}</ul>`);
 }


### PR DESCRIPTION
Fixes #12 

Summary of changes:
* Hides disabled (or ones that have no notes) standards/guidelines from the 'Applicable Standards/Guidelines' table.

**QA new report**

1. After deployment ('Deploy' action) is successful, open site https://civicactions.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the about page.
4. Scroll to the 'Disabled Chapters/Tables' section.
5. Check some of the boxes.
6. Click the 'View report' or 'Report' tab.
7. Confirm you see a 'Valid' message.
8. Confirm in the report the disabled standards/guidelines does not display in the 'Applicable Standards/Guidelines' table.
9. Also confirm the header is not displayed in the report.
10. Switch to the disabled chapter and add some notes.
11. Switch back to the 'Report' tab and confirm you do see the disabled standards/guidelines display in the 'Applicable Standards/Guidelines' table.

**QA existing report**

1. After deployment ('Deploy' action) is successful, open site https://civicactions.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR. Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/CivicActions/openacr/tree/main/openacr.
5. Switch to the about page.
6. Scroll to the 'Disabled Chapters/Tables' section.
7. Check some of the boxes.
8. Click the 'View report' or 'Report' tab.
10. Confirm you see a 'Valid' message.
12. Confirm in the report the disabled standards/guidelines does not display in the 'Applicable Standards/Guidelines' table.
13. Also confirm the header is not displayed in the report.
14. Switch to the disabled chapter and add some notes.
15. Switch back to the 'Report' tab and confirm you do see the disabled standards/guidelines display in the 'Applicable Standards/Guidelines' table.